### PR TITLE
Menu onclick issue fixed

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,4 +70,7 @@ function get_left_p_value() {
     }
 }
 
-
+const button = document.querySelector(".log-btn")
+button.addEventListener("click", () => {
+    window.alert("Log in Clicked")
+})


### PR DESCRIPTION
## What does this PR do?
Fixed the Menu onClick issue.

Fixes: #1 

**Current Behavior**
Now Menu is properly showing onClicked

**Previous Behavior**
When the menu toggle is clicked, the corresponding menu was not apearing

**Test:**
 - Go to home page
 - Click on the menu button